### PR TITLE
Fix base branch info for the release branches

### DIFF
--- a/release-deployment.md
+++ b/release-deployment.md
@@ -29,7 +29,7 @@ and how to deal with them from a branching point of view.
 | `master`      | YES        | N/A         | What is live in production (**stable**).<br/>A pull request is required to merge code into `master`. |
 | `develop`     | YES        | `master`    | The latest state of development (**unstable**). |
 | feature       | NO         | `develop`   | Cutting-edge features (**unstable**). These branches are used for any maintenance features / active development. |
-| `release-vX.Y.Z` | NO      | `master`    | A temporary release branch that follows the [semver](http://semver.org/) versioning. This is what is sent to UAT.<br/>A pull request is required to merge code into any `release-vX.Y.Z` branch. |
+| `release-vX.Y.Z` | NO      | `develop`    | A temporary release branch that follows the [semver](http://semver.org/) versioning. This is what is sent to UAT.<br/>A pull request is required to merge code into any `release-vX.Y.Z` branch. |
 | bugfix        | NO         | `release-vX.Y.Z` | Any fixes against a release branch should be made in a bug-fix branch. The bug-fix branch should be merged into the release branch and also into develop. This is one area where we’re deviating from GitFlow. |
 | `hotfix-*`    | NO         | `master`    | These are bug fixes against production.<br/>This is used because develop might have moved on from the last published state.<br/>Remember to merge this back into develop and any release branches. |
 


### PR DESCRIPTION
In order to match what’s written in the section ‘Create and deploy a
release’. Most of the times a release branch would be from develop.

What do you think @mikenikles ?