### PR TITLE
Update release deployment with a strategy for supporting old versions of projects

### DIFF
--- a/release-deployment.md
+++ b/release-deployment.md
@@ -158,20 +158,27 @@ Here is an example of creating a support branch for v1.0 assuming v2.0 of the pr
 1. Create the support branch and release branch for the patch release.
 
     ```
+    // Checkout the tag for the 1.0.0 release
     git checkout v1.0.0
+
+    // Create the long living support branch
     git checkout -b support-v1.x
+
+    // Create the release branch
     git checkout -b release-v1.0.1
     ```
 
+    Note: For subsequent releases (ex v1.0.2) the release branch will be branched off the `HEAD` of `support-v1.x`
+
 1. Make changes in the `release-v1.0.1`. Multiple PRs can be merged into this branch if several changes are necessary.
+
+1. As PRs are merged into the `release-v1.0.1` branch create associated PRs that cherry pick the changes back into `develop`. Ensure that these changes are desired by the team going forward and that they are compatible with the current state of the `develop` branch.
 
 1. Create release PR to merge `release-v1.0.1` into `support-v1.x`.
 
-1. Follow the standard release process treating `support-v1.x` as the `master` branch.
+1. Follow the standard release process treating `support-v1.x` as the `master` branch. As per the standard release process `release-v1.0.1` will get deleted and `support-v1.x` will remain in repo indefinitely.
 
 1. Mark `support-v1.x` as a protected branch in github so that it does not get accidentally deleted.
-
-1. As PRs are merged into the `release-v1.0.1` branch create associated PRs that cherry pick the changes back into `develop`. Ensure that these changes are desired by the team going forward and that they are compatible with the current state of the `develop` branch.
 
 *Pro-tip*: Try to maintain as few support branches as possible. These branches are expensive to maintain since you will need to cherry pick applicable bug fixes into each support branch seperately.
 

--- a/release-deployment.md
+++ b/release-deployment.md
@@ -138,20 +138,43 @@ There's nothing special about that. Each developer follows the above [Develop a 
 1. Finish off the tasks in the release checklist. Once everything is done, close
    the release PR.
 
-**TBD: Discuss**
-Mike N: Long-lived release branches, yes/no?
-
-1. Create the release on Github from `master`.
+1. Delete the release branch on Github.
 
 ### Change in plan, pull a feature from a release
 
 **TBD: Discuss**
 Mike N: That probably means recreating the release branch, unless we have short-lived release branches
 
-### Change request
+### Supporting old releases
 
-**TBD: Discuss**
-Mike N: That probably means recreating the release branch, unless we have short-lived release branches
+In a release based project old releases can often need some maintenance. Critical bug fixes and strategic feature requests need to be supported on old releases. Old releases often become incompatible with the most recent versions of projects.
+
+In order to support old release versions gitflow has introduced the concept of support branches. Support branches are long living branches created to support major or minor versions of the project. Support branches do not get merged back into `master` or `develop` (this would cause major merge issues which are time consuming and error prone if attempted). Instead commits can be cherry picked from the support branch back into `develop`. 
+
+Support branches can be thought of as the `master` branch for old releases. Support branches for major releases should be named as `support-v<major>.x`. Support branches for minor releases should be named as `support-v<major>.<minor>.x`.
+
+Here is an example of creating a support branch for v1.0 assuming v2.0 of the project has already been released.
+
+1. Create the support branch and release branch for the patch release.
+
+    ```
+    git checkout v1.0.0
+    git checkout -b support-v1.x
+    git checkout -b release-v1.0.1
+    ```
+
+1. Make changes in the `release-v1.0.1`. Multiple PRs can be merged into this branch if several changes are necessary.
+
+1. Create release PR to merge `release-v1.0.1` into `support-v1.x`.
+
+1. Follow the standard release process treating `support-v1.x` as the `master` branch.
+
+1. Mark `support-v1.x` as a protected branch in github so that it does not get accidentally deleted.
+
+1. As PRs are merged into the `release-v1.0.1` branch create associated PRs that cherry pick the changes back into `develop`. Ensure that these changes are desired by the team going forward and that they are compatible with the current state of the `develop` branch.
+
+*Pro-tip*: Try to maintain as few support branches as possible. These branches are expensive to maintain since you will need to cherry pick applicable bug fixes into each support branch seperately.
+
 
 ### Production hot fix
 


### PR DESCRIPTION
INTRODUCING the concept of the support branch. This concept became necessary on Astro to support v0.X versions of Astro after the release of v1.0. 

Having a formalized process for this concept going forward will help other teams move quickly in the support process. I believe the biggest benefit is the clear naming of the branches and knowing how to proced with respect to `master` and `develop` when making changes on old versions of the project.

Unfortunately having support branches is a bit of a maintenance overhead but the Astro team believes it is the easiest way going forward. Let's discuss if this will work Mobify wide for release deployments.

Mobify could look at supporting a select number of LTS releases for popular projects to reduce the maintenance overhead of these support branches. LTS branches is currently outside the scope of this PR.